### PR TITLE
Add group visit history

### DIFF
--- a/src/classes/groups.js
+++ b/src/classes/groups.js
@@ -8,6 +8,7 @@ import {
     groupRequest
 } from '../api';
 import $utils from './utils';
+import database from '../service/database.js';
 
 export default class extends baseClass {
     constructor(_app, _API, _t) {
@@ -507,7 +508,9 @@ export default class extends baseClass {
                 value: 'joinedAt:desc'
             },
             postsSearch: '',
-            galleries: {}
+            galleries: {},
+            lastVisit: '',
+            joinCount: 0
         },
         inviteGroupDialog: {
             visible: false,
@@ -776,6 +779,26 @@ export default class extends baseClass {
             D.galleries = {};
             D.members = [];
             D.memberFilter = this.groupDialogFilterOptions.everyone;
+            D.lastVisit = '';
+            D.joinCount = 0;
+            database.getGroupLastVisit({
+                groupId,
+                id: API.currentUser.id,
+                displayName: API.currentUser.displayName
+            }).then((ref) => {
+                if (ref.groupId === D.id) {
+                    D.lastVisit = ref.created_at;
+                }
+            });
+            database.getGroupJoinCount({
+                groupId,
+                id: API.currentUser.id,
+                displayName: API.currentUser.displayName
+            }).then((ref) => {
+                if (ref.groupId === D.id) {
+                    D.joinCount = ref.joinCount;
+                }
+            });
             API.getCachedGroup({
                 groupId
             })

--- a/src/components/dialogs/GroupDialog/GroupDialog.vue
+++ b/src/components/dialogs/GroupDialog/GroupDialog.vue
@@ -598,6 +598,35 @@
                         </div>
                         <div class="x-friend-item" style="cursor: default">
                             <div class="detail">
+                                <span class="name">{{ t('dialog.group.info.last_visited') }}</span>
+                                <span class="extra">
+                                    {{ groupDialog.lastVisit ? (groupDialog.lastVisit | formatDate('long')) : '-' }}
+                                    <span v-if="groupDialog.lastVisit"> ({{ daysSince(groupDialog.lastVisit) }}) </span>
+                                </span>
+                            </div>
+                        </div>
+                        <el-tooltip
+                            :disabled="hideTooltips"
+                            placement="top"
+                            :content="$t('dialog.user.info.open_previouse_instance')">
+                            <div class="x-friend-item" @click="showPreviousInstancesGroupDialog(groupDialog.ref)">
+                                <div class="detail">
+                                    <span class="name">
+                                        {{ t('dialog.group.info.join_count') }}
+                                        <el-tooltip
+                                            v-if="!hideTooltips"
+                                            placement="top"
+                                            style="margin-left: 5px"
+                                            :content="$t('dialog.world.info.accuracy_notice')">
+                                            <i class="el-icon-warning"></i>
+                                        </el-tooltip>
+                                    </span>
+                                    <span class="extra">{{ groupDialog.joinCount }}</span>
+                                </div>
+                            </div>
+                        </el-tooltip>
+                        <div class="x-friend-item" style="cursor: default">
+                            <div class="detail">
                                 <span class="name">{{ t('dialog.group.info.links') }}</span>
                                 <div
                                     v-if="groupDialog.ref.links && groupDialog.ref.links.length > 0"
@@ -1167,6 +1196,9 @@
             :online-friends="onlineFriends"
             :offline-friends="offlineFriends"
             :active-friends="activeFriends" />
+        <PreviousInstancesGroupDialog
+            :previous-instances-group-dialog.sync="previousInstancesGroupDialog"
+            :shift-held="shiftHeld" />
     </safe-dialog>
 </template>
 
@@ -1184,6 +1216,7 @@
     import InviteGroupDialog from '../InviteGroupDialog.vue';
     import GroupMemberModerationDialog from './GroupMemberModerationDialog.vue';
     import GroupPostEditDialog from './GroupPostEditDialog.vue';
+    import PreviousInstancesGroupDialog from '../PreviousInstancesDialog/PreviousInstancesGroupDialog.vue';
 
     const API = inject('API');
     const showFullscreenImageDialog = inject('showFullscreenImageDialog');
@@ -1293,6 +1326,12 @@
         userObject: {}
     });
 
+    const previousInstancesGroupDialog = ref({
+        visible: false,
+        openFlg: false,
+        groupRef: {}
+    });
+
     let loadMoreGroupMembersParams = {};
 
     watch(
@@ -1322,6 +1361,14 @@
         D.userId = userId;
         D.userObject = {};
         D.visible = true;
+    }
+
+    function showPreviousInstancesGroupDialog(groupRef) {
+        const D = previousInstancesGroupDialog.value;
+        D.groupRef = groupRef;
+        D.visible = true;
+        D.openFlg = true;
+        nextTick(() => (D.openFlg = false));
     }
 
     function setGroupRepresentation(groupId) {
@@ -1785,5 +1832,10 @@
     }
     function updateGroupPostSearch() {
         emit('updateGroupPostSearch');
+    }
+
+    function daysSince(date) {
+        if (!date) return '';
+        return Math.floor((Date.now() - Date.parse(date)) / 86400000);
     }
 </script>

--- a/src/components/dialogs/PreviousInstancesDialog/PreviousInstancesGroupDialog.vue
+++ b/src/components/dialogs/PreviousInstancesDialog/PreviousInstancesGroupDialog.vue
@@ -1,0 +1,150 @@
+<template>
+    <safe-dialog
+        ref="previousInstancesGroupDialog"
+        :visible.sync="isVisible"
+        :title="$t('dialog.previous_instances.header')"
+        width="1000px"
+        append-to-body>
+        <div style="display: flex; align-items: center; justify-content: space-between">
+            <span style="font-size: 14px" v-text="previousInstancesGroupDialog.groupRef.name"></span>
+            <el-input
+                v-model="previousInstancesGroupDialogTable.filters[0].value"
+                :placeholder="$t('dialog.previous_instances.search_placeholder')"
+                style="display: block; width: 150px"></el-input>
+        </div>
+        <data-tables v-loading="loading" v-bind="previousInstancesGroupDialogTable" style="margin-top: 10px">
+            <el-table-column :label="$t('table.previous_instances.date')" prop="created_at" sortable width="170">
+                <template slot-scope="scope">
+                    <span>{{ scope.row.created_at | formatDate('long') }}</span>
+                </template>
+            </el-table-column>
+            <el-table-column :label="$t('table.previous_instances.world')" prop="worldName" sortable>
+                <template slot-scope="scope">
+                    <location :location="scope.row.location" :hint="scope.row.worldName"></location>
+                </template>
+            </el-table-column>
+            <el-table-column :label="$t('table.previous_instances.instance_creator')" prop="location">
+                <template slot-scope="scope">
+                    <display-name :userid="scope.row.$location.userId" :location="scope.row.$location.tag"></display-name>
+                </template>
+            </el-table-column>
+            <el-table-column :label="$t('table.previous_instances.time')" prop="time" width="100" sortable>
+                <template slot-scope="scope">
+                    <span v-text="scope.row.timer"></span>
+                </template>
+            </el-table-column>
+            <el-table-column :label="$t('table.previous_instances.action')" width="90" align="right">
+                <template slot-scope="scope">
+                    <el-button type="text" icon="el-icon-switch-button" size="mini" @click="showLaunchDialog(scope.row.location)"></el-button>
+                    <el-button type="text" icon="el-icon-s-data" size="mini" @click="showPreviousInstancesInfoDialog(scope.row.location)"></el-button>
+                    <el-button v-if="shiftHeld" style="color: #f56c6c" type="text" icon="el-icon-close" size="mini" @click="deleteGameLogGroupInstance(scope.row)"></el-button>
+                    <el-button v-else type="text" icon="el-icon-close" size="mini" @click="deleteGameLogGroupInstancePrompt(scope.row)"></el-button>
+                </template>
+            </el-table-column>
+        </data-tables>
+    </safe-dialog>
+</template>
+
+<script>
+import utils from '../../../classes/utils';
+import { parseLocation } from '../../../composables/instance/utils';
+import database from '../../../service/database';
+import Location from '../../Location.vue';
+
+export default {
+    name: 'PreviousInstancesGroupDialog',
+    components: { Location },
+    inject: ['showLaunchDialog', 'showPreviousInstancesInfoDialog', 'adjustDialogZ'],
+    props: {
+        previousInstancesGroupDialog: {
+            type: Object,
+            required: true
+        },
+        shiftHeld: Boolean
+    },
+    data() {
+        return {
+            previousInstancesGroupDialogTable: {
+                data: [],
+                filters: [
+                    {
+                        prop: 'worldName',
+                        value: ''
+                    }
+                ],
+                tableProps: {
+                    stripe: true,
+                    size: 'mini',
+                    defaultSort: {
+                        prop: 'created_at',
+                        order: 'descending'
+                    }
+                },
+                pageSize: 10,
+                paginationProps: {
+                    small: true,
+                    layout: 'sizes,prev,pager,next,total',
+                    pageSizes: [10, 25, 50, 100]
+                }
+            },
+            loading: false
+        };
+    },
+    computed: {
+        isVisible: {
+            get() {
+                return this.previousInstancesGroupDialog.visible;
+            },
+            set(value) {
+                this.$emit('update:previous-instances-group-dialog', {
+                    ...this.previousInstancesGroupDialog,
+                    visible: value
+                });
+            }
+        }
+    },
+    watch: {
+        'previousInstancesGroupDialog.openFlg'() {
+            if (this.previousInstancesGroupDialog.visible) {
+                this.$nextTick(() => {
+                    this.adjustDialogZ(this.$refs.previousInstancesGroupDialog.$el);
+                });
+                this.refreshPreviousInstancesGroupTable();
+            }
+        }
+    },
+    methods: {
+        refreshPreviousInstancesGroupTable() {
+            this.loading = true;
+            const D = this.previousInstancesGroupDialog;
+            database.getpreviousInstancesByGroupId(D.groupRef).then((data) => {
+                const array = [];
+                for (const ref of data.values()) {
+                    ref.$location = parseLocation(ref.location);
+                    ref.timer = ref.time > 0 ? utils.timeToText(ref.time) : '';
+                    array.push(ref);
+                }
+                array.sort(utils.compareByCreatedAt);
+                this.previousInstancesGroupDialogTable.data = array;
+                this.loading = false;
+            });
+        },
+        deleteGameLogGroupInstance(row) {
+            database.deleteGameLogInstanceByInstanceId({ location: row.location });
+            utils.removeFromArray(this.previousInstancesGroupDialogTable.data, row);
+        },
+        deleteGameLogGroupInstancePrompt(row) {
+            this.$confirm('Continue? Delete GameLog Instance', 'Confirm', {
+                confirmButtonText: 'Confirm',
+                cancelButtonText: 'Cancel',
+                type: 'info',
+                callback: (action) => {
+                    if (action === 'confirm') {
+                        this.deleteGameLogGroupInstance(row);
+                    }
+                }
+            });
+        }
+    }
+};
+</script>

--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -1055,6 +1055,8 @@
                 "rules": "Rules",
                 "members": "Members",
                 "created_at": "Created At",
+                "last_visited": "Last Visited",
+                "join_count": "Join Count",
                 "links": "Links",
                 "url": "Group URL",
                 "url_tooltip": "Copy URL to clipboard",


### PR DESCRIPTION
## Summary
- track last visit and join count for groups
- add a dialog to list previous group instances
- show last visit date and days ago in group dialog
- make join count clickable to open group instances dialog
- provide English translations for new labels

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d5a17b9c883338c09b665b6b21731