### PR TITLE
Fix closable group history dialog

### DIFF
--- a/src/components/dialogs/PreviousInstancesDialog/PreviousInstancesGroupDialog.vue
+++ b/src/components/dialogs/PreviousInstancesDialog/PreviousInstancesGroupDialog.vue
@@ -115,7 +115,7 @@ export default {
                 return this.previousInstancesGroupDialog.visible;
             },
             set(value) {
-                this.$emit('update:previous-instances-group-dialog', {
+                this.$emit('update:previousInstancesGroupDialog', {
                     ...this.previousInstancesGroupDialog,
                     visible: value
                 });


### PR DESCRIPTION
## Summary
- fix event name used by previous instances dialog

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d759a989c8333aa1839e4eb927ca0