### PR TITLE
Fix reopening group last visited dialog

### DIFF
--- a/src/components/dialogs/GroupDialog/GroupDialog.vue
+++ b/src/components/dialogs/GroupDialog/GroupDialog.vue
@@ -1312,7 +1312,7 @@ import PreviousInstancesGroupDialog from "../PreviousInstancesDialog/PreviousIns
         userObject: {}
     });
 
-    const previousInstancesGroupDialog = reactive({
+    const previousInstancesGroupDialog = ref({
         visible: false,
         openFlg: false,
         groupRef: {}
@@ -1350,7 +1350,7 @@ import PreviousInstancesGroupDialog from "../PreviousInstancesDialog/PreviousIns
     }
 
     function showPreviousInstancesGroupDialog(groupRef) {
-        const D = previousInstancesGroupDialog;
+        const D = previousInstancesGroupDialog.value;
         D.groupRef = groupRef;
         D.visible = true;
         D.openFlg = true;


### PR DESCRIPTION
## Summary
- use a `ref` for `previousInstancesGroupDialog`
- update handler to modify `.value`

The dialog for "Last Visited" only opened once because the update emitted from `PreviousInstancesGroupDialog.vue` tried to reassign a constant `reactive` object. Switching to `ref` and adjusting the open method allows the dialog to be reopened.

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d78f1dda8833394a5f1286f6e3110