### PR TITLE
Add 'ban from group' option to user menu

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -80,6 +80,7 @@ import FullscreenImageDialog from './components/dialogs/FullscreenImageDialog.vu
 import GalleryDialog from './components/dialogs/GalleryDialog.vue';
 import GroupDialog from './components/dialogs/GroupDialog/GroupDialog.vue';
 import InviteGroupDialog from './components/dialogs/InviteGroupDialog.vue';
+import BanGroupDialog from './components/dialogs/BanGroupDialog.vue';
 import LaunchDialog from './components/dialogs/LaunchDialog.vue';
 import PreviousInstancesInfoDialog from './components/dialogs/PreviousInstancesDialog/PreviousInstancesInfoDialog.vue';
 
@@ -310,6 +311,7 @@ console.log(`isLinux: ${LINUX}`);
             //  - group
             GroupDialog,
             InviteGroupDialog,
+            BanGroupDialog,
             //  - avatar
             AvatarDialog,
             //  - favorites

--- a/src/components/dialogs/BanGroupDialog.vue
+++ b/src/components/dialogs/BanGroupDialog.vue
@@ -1,0 +1,122 @@
+<template>
+    <safe-dialog
+        ref="banGroupDialog"
+        :visible.sync="banGroupDialog.visible"
+        :title="$t('dialog.ban_from_group.header')"
+        width="450px"
+        append-to-body>
+        <div v-if="banGroupDialog.visible" v-loading="banGroupDialog.loading">
+            <span>{{ $t('dialog.ban_from_group.description') }}</span>
+            <br />
+            <el-select
+                v-model="banGroupDialog.groupId"
+                clearable
+                :placeholder="$t('dialog.ban_from_group.choose_group_placeholder')"
+                filterable
+                :disabled="banGroupDialog.loading"
+                style="margin-top: 15px">
+                <el-option-group
+                    v-if="eligibleGroups.length"
+                    :label="$t('dialog.ban_from_group.groups')"
+                    style="width: 410px">
+                    <el-option
+                        v-for="group in eligibleGroups"
+                        :key="group.id"
+                        :label="group.name"
+                        :value="group.id"
+                        style="height: auto"
+                        class="x-friend-item">
+                        <div class="avatar">
+                            <img v-lazy="group.iconUrl" />
+                        </div>
+                        <div class="detail">
+                            <span class="name" v-text="group.name"></span>
+                        </div>
+                    </el-option>
+                </el-option-group>
+            </el-select>
+        </div>
+        <template #footer>
+            <el-button
+                type="primary"
+                size="small"
+                :disabled="banGroupDialog.loading || !banGroupDialog.groupId"
+                @click="banUser">
+                Ban
+            </el-button>
+        </template>
+    </safe-dialog>
+</template>
+
+<script>
+import { groupRequest } from '../../api';
+import { hasGroupPermission } from '../../composables/group/utils';
+
+export default {
+    name: 'BanGroupDialog',
+    inject: ['API', 'adjustDialogZ', '$message', '$confirm'],
+    props: {
+        dialogData: {
+            type: Object,
+            required: true
+        }
+    },
+    computed: {
+        banGroupDialog: {
+            get() {
+                return this.dialogData;
+            },
+            set(value) {
+                this.$emit('update:dialog-data', value);
+            }
+        },
+        eligibleGroups() {
+            const groups = [];
+            for (const group of this.API.currentUserGroups.values()) {
+                if (hasGroupPermission(group, 'group-bans-manage')) {
+                    groups.push(group);
+                }
+            }
+            return groups;
+        }
+    },
+    watch: {
+        'dialogData.visible'(value) {
+            if (value) {
+                this.initDialog();
+            }
+        }
+    },
+    methods: {
+        initDialog() {
+            this.$nextTick(() => this.adjustDialogZ(this.$refs.banGroupDialog.$el));
+        },
+        banUser() {
+            this.$confirm('Continue? Ban User From Group', 'Confirm', {
+                confirmButtonText: 'Confirm',
+                cancelButtonText: 'Cancel',
+                type: 'warning',
+                callback: (action) => {
+                    if (action !== 'confirm') return;
+                    const D = this.banGroupDialog;
+                    if (!D.groupId || !D.userId) return;
+                    D.loading = true;
+                    groupRequest
+                        .banGroupMember({ groupId: D.groupId, userId: D.userId })
+                        .then(() => {
+                            this.$message({ type: 'success', message: 'User banned' });
+                            this.banGroupDialog.visible = false;
+                        })
+                        .catch((err) => {
+                            console.error(err);
+                            this.$message({ type: 'error', message: 'Failed to ban user' });
+                        })
+                        .finally(() => {
+                            D.loading = false;
+                        });
+                }
+            });
+        }
+    }
+};
+</script>

--- a/src/components/dialogs/UserDialog/UserDialog.vue
+++ b/src/components/dialogs/UserDialog/UserDialog.vue
@@ -433,6 +433,9 @@
                                     <el-dropdown-item icon="el-icon-message" command="Invite To Group">{{
                                         t('dialog.user.actions.invite_to_group')
                                     }}</el-dropdown-item>
+                                    <el-dropdown-item icon="el-icon-remove-outline" command="Ban From Group">{{
+                                        t('dialog.user.actions.ban_from_group')
+                                    }}</el-dropdown-item>
                                     <!--//- el-dropdown-item(icon="el-icon-thumb" command="Send Boop" :disabled="!API.currentUser.isBoopingEnabled") {{ t('dialog.user.actions.send_boop') }}-->
                                     <el-dropdown-item icon="el-icon-s-custom" command="Show Avatar Author" divided>{{
                                         t('dialog.user.actions.show_avatar_author')
@@ -1785,6 +1788,7 @@
             :online-friends="onlineFriends"
             :offline-friends="offlineFriends"
             :active-friends="activeFriends" />
+        <BanGroupDialog :dialog-data.sync="banGroupDialog" />
         <SocialStatusDialog
             :social-status-dialog="socialStatusDialog"
             :social-status-history-table="socialStatusHistoryTable" />
@@ -1823,6 +1827,7 @@
     import Location from '../../Location.vue';
     import SendInviteDialog from '../InviteDialog/SendInviteDialog.vue';
     import InviteGroupDialog from '../InviteGroupDialog.vue';
+    import BanGroupDialog from '../BanGroupDialog.vue';
     import PreviousImagesDialog from '../PreviousImagesDialog.vue';
     import BioDialog from './BioDialog.vue';
     import LanguageDialog from './LanguageDialog.vue';
@@ -2030,6 +2035,13 @@
         userId: '',
         userIds: [],
         userObject: {}
+    });
+
+    const banGroupDialog = ref({
+        visible: false,
+        loading: false,
+        groupId: '',
+        userId: ''
     });
 
     const socialStatusDialog = ref({
@@ -2309,6 +2321,13 @@
         D.visible = true;
     }
 
+    function showBanGroupDialog(groupId, userId) {
+        const D = banGroupDialog.value;
+        D.groupId = groupId;
+        D.userId = userId;
+        D.visible = true;
+    }
+
     function userDialogCommand(command) {
         let L;
         const D = props.userDialog;
@@ -2412,6 +2431,8 @@
             showGalleryDialog();
         } else if (command === 'Invite To Group') {
             showInviteGroupDialog('', D.id);
+        } else if (command === 'Ban From Group') {
+            showBanGroupDialog('', D.id);
             // } else if (command === 'Send Boop') {
             //     this.showSendBoopDialog(D.id);
         } else if (command === 'Hide Avatar') {

--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -728,6 +728,7 @@
                 "request_invite": "Request Invite",
                 "request_invite_with_message": "Request Invite With Message",
                 "invite_to_group": "Invite To Group",
+                "ban_from_group": "Ban From Group",
                 "send_boop": "Send Boop",
                 "manage_gallery_inventory_icon": "Manage VRC+ Images & Inventory",
                 "accept_friend_request": "Accept Friend Request",
@@ -1391,6 +1392,12 @@
             "groups": "Groups",
             "choose_friends_placeholder": "Choose Friends",
             "selected_users": "Selected Users"
+        },
+        "ban_from_group": {
+            "header": "Ban From Group",
+            "description": "Select a group you can ban from.",
+            "choose_group_placeholder": "Choose Group",
+            "groups": "Groups"
         },
         "note_export": {
             "header": "Note Export",


### PR DESCRIPTION
## Summary
- add a dialog to ban a user from a group
- expose new dialog component and hook it to App
- show **Ban From Group** entry in user profile menu
- provide English localization for new strings

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68713f7a4c3083339b052b13a1c7b218