### PR TITLE
Add custom avatar preview image support

### DIFF
--- a/Dotnet/AppApi/Common/AvatarImage.cs
+++ b/Dotnet/AppApi/Common/AvatarImage.cs
@@ -1,0 +1,23 @@
+using System.IO;
+
+namespace VRCX
+{
+    public partial class AppApi
+    {
+        public string AvatarImagePath(string avatarId)
+        {
+            if (string.IsNullOrEmpty(avatarId))
+                return string.Empty;
+
+            var folder = Path.Join(Program.AppDataDirectory, "AvatarImages");
+            if (!Directory.Exists(folder))
+                Directory.CreateDirectory(folder);
+
+            var filePath = Path.Join(folder, $"{avatarId}.png");
+            if (File.Exists(filePath))
+                return filePath;
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/components/dialogs/AvatarDialog/AvatarDialog.vue
+++ b/src/components/dialogs/AvatarDialog/AvatarDialog.vue
@@ -10,14 +10,14 @@
                 <el-popover placement="right" width="500px" trigger="click">
                     <img
                         slot="reference"
-                        v-lazy="avatarDialog.ref.thumbnailImageUrl"
+                        v-lazy="localAvatarImage || avatarDialog.ref.thumbnailImageUrl"
                         class="x-link"
                         style="flex: none; width: 160px; height: 120px; border-radius: 12px" />
                     <img
-                        v-lazy="avatarDialog.ref.imageUrl"
+                        v-lazy="localAvatarImage || avatarDialog.ref.imageUrl"
                         class="x-link"
                         style="width: 500px; height: 375px"
-                        @click="showFullscreenImageDialog(avatarDialog.ref.imageUrl)" />
+                        @click="showFullscreenImageDialog(localAvatarImage || avatarDialog.ref.imageUrl)" />
                 </el-popover>
                 <div style="flex: 1; display: flex; align-items: center; margin-left: 15px">
                     <div style="flex: 1">
@@ -661,6 +661,7 @@
     const previousImagesFileId = ref('');
     const previousImagesDialogVisible = ref(false);
     const previousImagesTable = ref([]);
+    const localAvatarImage = ref('');
 
     const treeData = ref([]);
     const timeSpent = ref(0);
@@ -733,6 +734,25 @@
                 handleDialogOpen();
             }
         }
+    );
+
+    watch(
+        () => props.avatarDialog.id,
+        (newId) => {
+            if (!newId) {
+                localAvatarImage.value = '';
+                return;
+            }
+            AppApi.AvatarImagePath(newId).then((filePath) => {
+                if (newId !== props.avatarDialog.id) return;
+                if (filePath) {
+                    localAvatarImage.value = `file://${filePath.replace(/\\/g, '/')}`;
+                } else {
+                    localAvatarImage.value = '';
+                }
+            });
+        },
+        { immediate: true }
     );
 
     function handleDialogOpen() {


### PR DESCRIPTION
## Summary
- show local avatar preview images if available
- expose AvatarImagePath in AppApi

## Testing
- `npm run` (list available scripts)
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68722273cf9c833387746bfd2529cba0