### PR TITLE
Add local avatar preview option

### DIFF
--- a/Dotnet/AppApi/Common/AvatarImage.cs
+++ b/Dotnet/AppApi/Common/AvatarImage.cs
@@ -19,5 +19,27 @@ namespace VRCX
 
             return string.Empty;
         }
+
+        public string SaveAvatarPreviewImage(string sourcePath, string avatarId)
+        {
+            if (string.IsNullOrEmpty(sourcePath) || string.IsNullOrEmpty(avatarId))
+                return string.Empty;
+
+            var folder = Path.Join(Program.AppDataDirectory, "AvatarImages");
+            if (!Directory.Exists(folder))
+                Directory.CreateDirectory(folder);
+
+            var filePath = Path.Join(folder, $"{avatarId}.png");
+
+            try
+            {
+                File.Copy(sourcePath, filePath, true);
+                return filePath;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
     }
 }

--- a/src/components/dialogs/AvatarDialog/AvatarDialog.vue
+++ b/src/components/dialogs/AvatarDialog/AvatarDialog.vue
@@ -330,6 +330,9 @@
                                     <el-dropdown-item icon="el-icon-picture-outline" command="Change Image">{{
                                         t('dialog.avatar.actions.change_image')
                                     }}</el-dropdown-item>
+                                    <el-dropdown-item icon="el-icon-picture-outline" command="Set Local Image">{{
+                                        t('dialog.avatar.actions.set_local_image')
+                                    }}</el-dropdown-item>
                                     <el-dropdown-item
                                         v-if="avatarDialog.ref.unityPackageUrl"
                                         icon="el-icon-download"
@@ -811,6 +814,9 @@
             case 'Change Image':
                 displayPreviousImages('Change');
                 break;
+            case 'Set Local Image':
+                selectLocalAvatarImage(D.id);
+                break;
             case 'Previous Images':
                 displayPreviousImages('Display');
                 break;
@@ -1050,6 +1056,23 @@
                 });
                 return args;
             });
+    }
+
+    async function selectLocalAvatarImage(id) {
+        let filePath = '';
+        // eslint-disable-next-line no-undef
+        if (LINUX) {
+            filePath = await window.electron.openFileDialog();
+        } else {
+            filePath = await AppApi.OpenFileSelectorDialog(null, '.png', 'PNG Files (*.png)|*.png');
+        }
+        if (!filePath) {
+            return;
+        }
+        const savedPath = await AppApi.SaveAvatarPreviewImage(filePath, id);
+        if (savedPath) {
+            localAvatarImage.value = `file://${savedPath.replace(/\\/g, '/')}`;
+        }
     }
 
     function promptChangeAvatarDescription(avatar) {

--- a/src/localization/cz/en.json
+++ b/src/localization/cz/en.json
@@ -839,6 +839,7 @@
                 "change_description": "Change Description",
                 "change_content_tags": "Change Content Tags",
                 "change_image": "Change Image",
+                "set_local_image": "Set Local Image",
                 "download_package": "Download Unity Package",
                 "delete": "Delete",
                 "delete_impostor": "Delete Impostor",

--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -979,6 +979,7 @@
                 "change_content_tags": "Change Content Tags",
                 "change_styles_author_tags": "Change Styles and Author Tags",
                 "change_image": "Change Image",
+                                "set_local_image": "Set Local Image",
                 "download_package": "Download Unity Package",
                 "delete": "Delete",
                 "delete_impostor": "Delete Impostor",

--- a/src/localization/es/en.json
+++ b/src/localization/es/en.json
@@ -957,6 +957,7 @@
                 "change_description": "Cambiar Descripción",
                 "change_content_tags": "Cambiar Etiquetas de Contenido",
                 "change_image": "Cambiar Imagen",
+                "set_local_image": "Set Local Image",
                 "download_package": "Descargar Paquete de Unity",
                 "delete": "Eliminar",
                 "delete_impostor": "Eliminar Impostor",

--- a/src/localization/fr/en.json
+++ b/src/localization/fr/en.json
@@ -907,6 +907,7 @@
                 "change_description": "Changer la description",
                 "change_content_tags": "Modifier les tags",
                 "change_image": "Changer l'image",
+                "set_local_image": "Set Local Image",
                 "download_package": "Télécharger le package Unity",
                 "delete": "Supprimer",
                 "delete_impostor": "Supprimer l'imposteur",

--- a/src/localization/hu/en.json
+++ b/src/localization/hu/en.json
@@ -792,6 +792,7 @@
                 "change_description": "Change Description",
                 "change_content_tags": "Change Content Tags",
                 "change_image": "Change Image",
+                "set_local_image": "Set Local Image",
                 "download_package": "Download Unity Package",
                 "delete": "Törlés",
                 "delete_impostor": "Delete Impostor",

--- a/src/localization/ja/en.json
+++ b/src/localization/ja/en.json
@@ -960,6 +960,7 @@
                 "change_description": "説明を変更",
                 "change_content_tags": "コンテンツタグを変更",
                 "change_image": "画像を変更",
+                "set_local_image": "Set Local Image",
                 "download_package": "Unity Packageをダウンロード",
                 "delete": "削除",
                 "delete_impostor": "インポスターを削除",

--- a/src/localization/ko/en.json
+++ b/src/localization/ko/en.json
@@ -792,6 +792,7 @@
                 "change_description": "설명 변경",
                 "change_content_tags": "Change Content Tags",
                 "change_image": "이미지 변경",
+                "set_local_image": "Set Local Image",
                 "download_package": "유니티 패키지 다운로드",
                 "delete": "삭제",
                 "delete_impostor": "Delete Impostor",

--- a/src/localization/pl/en.json
+++ b/src/localization/pl/en.json
@@ -792,6 +792,7 @@
                 "change_description": "Zmień opis",
                 "change_content_tags": "Zmień ostrzeżenia zawartości",
                 "change_image": "Zmień obrazek",
+                "set_local_image": "Set Local Image",
                 "download_package": "Pobierz paczkę Unity",
                 "delete": "Usuń",
                 "delete_impostor": "Usuń Impostora",

--- a/src/localization/pt/en.json
+++ b/src/localization/pt/en.json
@@ -792,6 +792,7 @@
                 "change_description": "Mudar Descrição",
                 "change_content_tags": "Mudar Etiquetas de Conteúdo",
                 "change_image": "Mudar Imagem",
+                "set_local_image": "Set Local Image",
                 "download_package": "Baixar Pacote Unity",
                 "delete": "Excluir",
                 "delete_impostor": "Excluir Impostor",

--- a/src/localization/ru/en.json
+++ b/src/localization/ru/en.json
@@ -961,6 +961,7 @@
                 "change_description": "Изменить описание",
                 "change_content_tags": "Изменить теги содержимого",
                 "change_image": "Изменить изображение",
+                "set_local_image": "Set Local Image",
                 "download_package": "Скачать пакет Unity",
                 "delete": "Удалить",
                 "delete_impostor": "Удалить импостора",

--- a/src/localization/vi/en.json
+++ b/src/localization/vi/en.json
@@ -792,6 +792,7 @@
                 "change_description": "Đổi mô tả",
                 "change_content_tags": "Change Content Tags",
                 "change_image": "Đổi ảnh",
+                "set_local_image": "Set Local Image",
                 "download_package": "Tải về Unity Package",
                 "delete": "Xóa",
                 "delete_impostor": "Delete Impostor",

--- a/src/localization/zh-CN/en.json
+++ b/src/localization/zh-CN/en.json
@@ -963,6 +963,7 @@
                 "change_content_tags": "更改内容标签",
                 "change_styles": "更改风格",
                 "change_image": "更改封面",
+                "set_local_image": "Set Local Image",
                 "download_package": "下载 Unity Package",
                 "delete": "删除",
                 "delete_impostor": "删除模型替身",

--- a/src/localization/zh-TW/en.json
+++ b/src/localization/zh-TW/en.json
@@ -961,6 +961,7 @@
                 "change_description": "變更敘述",
                 "change_content_tags": "變更世界內容標籤",
                 "change_image": "變更圖片",
+                "set_local_image": "Set Local Image",
                 "download_package": "下載 Unity Package",
                 "delete": "刪除",
                 "delete_impostor": "刪除投影替身",


### PR DESCRIPTION
## Summary
- add API method `SaveAvatarPreviewImage` to save avatar preview images
- allow selecting a local preview image for avatars
- add `set_local_image` localization string across languages

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687226790778833382436097b17e5941