### PR TITLE
Fix avatar preview overlay behavior

### DIFF
--- a/src/views/Favorites/components/FavoritesAvatarItem.vue
+++ b/src/views/Favorites/components/FavoritesAvatarItem.vue
@@ -268,6 +268,9 @@ export default {
 
 <style scoped>
 /* Enlarge avatar preview on hover */
+.avatar {
+    position: relative;
+}
 .avatar img {
     transition: width 0.2s ease-in-out,
         height 0.2s ease-in-out,
@@ -276,7 +279,9 @@ export default {
 }
 
 .avatar:hover img {
-    position: relative;
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 300px;
     height: 300px;
     border-radius: 0;


### PR DESCRIPTION
## Summary
- make avatar preview overlay other items without shifting layout
- run production build to verify compilation

## Testing
- `npm run prod`

------
https://chatgpt.com/codex/tasks/task_e_68725b1fc4b483338f68f6ea18373324