### PR TITLE
Add Avatar Gallery page

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -83,6 +83,7 @@ import FeedTab from './views/Feed/Feed.vue';
 import SearchTab from './views/Search/Search.vue';
 import ProfileTab from './views/Profile/Profile.vue';
 import PlayerListTab from './views/PlayerList/PlayerList.vue';
+import AvatarGalleryTab from './views/AvatarGallery/AvatarGallery.vue';
 
 // components
 import SimpleSwitch from './components/SimpleSwitch.vue';
@@ -277,6 +278,7 @@ console.log(`isLinux: ${LINUX}`);
             ChartsTab,
             FriendListTab,
             FavoritesTab,
+            AvatarGalleryTab,
             NotificationTab,
             SearchTab,
             // - others
@@ -13787,6 +13789,15 @@ console.log(`isLinux: ${LINUX}`);
             'new-local-world-favorite-group': this.newLocalWorldFavoriteGroup,
             'rename-local-world-favorite-group':
                 this.renameLocalWorldFavoriteGroup
+        };
+    };
+
+    $app.computed.avatarGalleryTabBind = function () {
+        return {
+            menuActiveIndex: this.menuActiveIndex,
+            favoriteAvatars: this.favoriteAvatars,
+            localAvatarFavoriteGroups: this.localAvatarFavoriteGroups,
+            localAvatarFavorites: this.localAvatarFavorites
         };
     };
 

--- a/src/app.pug
+++ b/src/app.pug
@@ -37,6 +37,8 @@ doctype html
 
         FavoritesTab(v-bind='favoritesTabBind' v-on='favoritesTabEvent')
 
+        AvatarGalleryTab(v-bind='avatarGalleryTabBind')
+
         FriendLogTab(v-bind='friendLogTabBind')
 
         ModerationTab(v-bind='moderationTabBind')

--- a/src/components/NavMenu.vue
+++ b/src/components/NavMenu.vue
@@ -40,6 +40,13 @@
             </template>
         </el-menu-item>
 
+        <el-menu-item index="avatarGallery">
+            <i class="el-icon-picture-outline"></i>
+            <template slot="title">
+                <span>{{ $t('nav_tooltip.avatar_gallery') }}</span>
+            </template>
+        </el-menu-item>
+
         <el-menu-item index="friendLog">
             <i class="el-icon-notebook-2"></i>
             <template slot="title">

--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -7,6 +7,7 @@
         "player_list": "Player List",
         "search": "Search",
         "favorites": "Favorites",
+        "avatar_gallery": "Avatar Gallery",
         "friend_log": "Friend Log",
         "moderation": "Moderation",
         "notification": "Notification",

--- a/src/views/AvatarGallery/AvatarGallery.vue
+++ b/src/views/AvatarGallery/AvatarGallery.vue
@@ -1,0 +1,107 @@
+<template>
+    <div v-show="menuActiveIndex === 'avatarGallery'" class="x-container">
+        <div style="padding: 10px">
+            <el-input
+                v-model="filter"
+                clearable
+                placeholder="Filter tags"
+                size="mini"
+                style="width: 200px; margin-bottom: 10px"
+            />
+            <div class="gallery">
+                <div
+                    v-for="avatar in filteredAvatars"
+                    :key="avatar.id"
+                    class="avatar-card"
+                    @click="showAvatarDialog(avatar.id)"
+                >
+                    <img v-lazy="avatar.thumbnailImageUrl" :alt="avatar.name" class="avatar" />
+                    <div class="avatar-name">{{ avatar.name }}</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'AvatarGallery',
+    inject: ['showAvatarDialog'],
+    props: {
+        menuActiveIndex: String,
+        favoriteAvatars: Array,
+        localAvatarFavoriteGroups: Array,
+        localAvatarFavorites: Object
+    },
+    data() {
+        return { filter: '' };
+    },
+    computed: {
+        allAvatars() {
+            const avatars = [];
+            const idSet = new Set();
+            for (const fav of this.favoriteAvatars) {
+                if (fav.ref && !idSet.has(fav.id)) {
+                    const tags = [];
+                    if (Array.isArray(fav.ref.tags)) tags.push(...fav.ref.tags);
+                    if (fav.groupKey) {
+                        const parts = fav.groupKey.split(':');
+                        if (parts.length > 1) tags.push(parts[1]);
+                    }
+                    avatars.push({ ...fav.ref, tags });
+                    idSet.add(fav.id);
+                }
+            }
+            for (const group of this.localAvatarFavoriteGroups) {
+                const list = this.localAvatarFavorites[group] || [];
+                for (const av of list) {
+                    if (!idSet.has(av.id)) {
+                        avatars.push({ ...av, tags: av.tags || [] });
+                        idSet.add(av.id);
+                    }
+                }
+            }
+            return avatars;
+        },
+        filteredAvatars() {
+            const f = this.filter.trim().toLowerCase();
+            if (!f) return this.allAvatars;
+            return this.allAvatars.filter((a) =>
+                (a.tags || []).some((t) => String(t).toLowerCase().includes(f))
+            );
+        }
+    }
+};
+</script>
+
+<style scoped>
+.gallery {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+}
+.avatar-card {
+    background: #1e1e1e;
+    border-radius: 12px;
+    width: 200px;
+    padding: 5px;
+    box-sizing: border-box;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    text-align: center;
+    color: white;
+}
+.avatar {
+    width: 190px;
+    height: 190px;
+    object-fit: cover;
+    border-radius: 8px;
+    background-color: #1e1e1e;
+    display: block;
+    margin: 0 auto;
+}
+.avatar-name {
+    margin-top: 12px;
+    font-size: 16px;
+    font-weight: bold;
+}
+</style>


### PR DESCRIPTION
## Summary
- implement new `AvatarGallery` main page to view all avatars
- hook new page into nav menu and app layout
- expose binder for AvatarGallery
- add localization entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68738d1dfd8c8333aeeea4bcb9f37f43