### PR TITLE
Add Avatar Gallery page

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -154,6 +154,7 @@ import EditInviteMessageDialog from './views/Profile/dialogs/EditInviteMessageDi
 import ExportAvatarsListDialog from './views/Profile/dialogs/ExportAvatarsListDialog.vue';
 import ExportFriendsListDialog from './views/Profile/dialogs/ExportFriendsListDialog.vue';
 import ProfileTab from './views/Profile/Profile.vue';
+import AvatarGallery from './views/AvatarGallery/AvatarGallery.vue';
 import SearchTab from './views/Search/Search.vue';
 import AvatarProviderDialog from './views/Settings/dialogs/AvatarProviderDialog.vue';
 import ChangelogDialog from './views/Settings/dialogs/ChangelogDialog.vue';
@@ -283,6 +284,7 @@ console.log(`isLinux: ${LINUX}`);
             ChartsTab,
             FriendListTab,
             FavoritesTab,
+            AvatarGallery,
             NotificationTab,
             SearchTab,
             // - others
@@ -5428,6 +5430,36 @@ console.log(`isLinux: ${LINUX}`);
             return this.favoriteAvatars_;
         }
         return this.favoriteAvatarsSorted;
+    };
+
+    $app.computed.avatarGalleryAvatars = function () {
+        const avatars = [];
+        for (const fav of this.favoriteAvatars) {
+            if (fav.ref) {
+                const tags = [];
+                if (fav.$groupRef && fav.$groupRef.displayName) {
+                    tags.push(fav.$groupRef.displayName);
+                }
+                avatars.push({
+                    id: fav.ref.id,
+                    name: fav.ref.name,
+                    thumbnailImageUrl: fav.ref.thumbnailImageUrl,
+                    tags
+                });
+            }
+        }
+        for (const group of this.localAvatarFavoriteGroups) {
+            const list = this.localAvatarFavorites[group] || [];
+            for (const ref of list) {
+                avatars.push({
+                    id: ref.id,
+                    name: ref.name,
+                    thumbnailImageUrl: ref.thumbnailImageUrl,
+                    tags: [group]
+                });
+            }
+        }
+        return avatars;
     };
 
     // #endregion
@@ -13892,6 +13924,13 @@ console.log(`isLinux: ${LINUX}`);
             'new-local-world-favorite-group': this.newLocalWorldFavoriteGroup,
             'rename-local-world-favorite-group':
                 this.renameLocalWorldFavoriteGroup
+        };
+    };
+
+    $app.computed.avatarGalleryTabBind = function () {
+        return {
+            menuActiveIndex: this.menuActiveIndex,
+            galleryAvatars: this.avatarGalleryAvatars
         };
     };
 

--- a/src/app.pug
+++ b/src/app.pug
@@ -37,6 +37,8 @@ doctype html
 
         FavoritesTab(v-bind='favoritesTabBind' v-on='favoritesTabEvent')
 
+        AvatarGallery(v-bind='avatarGalleryTabBind')
+
         FriendLogTab(v-bind='friendLogTabBind')
 
         ModerationTab(v-bind='moderationTabBind')

--- a/src/components/AvatarCard.vue
+++ b/src/components/AvatarCard.vue
@@ -1,0 +1,45 @@
+<template>
+    <div class="avatar-card">
+        <img :src="avatar.thumbnailImageUrl" alt="Avatar" class="avatar" />
+        <div class="avatar-name">{{ avatar.name }}</div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'AvatarCard',
+    props: {
+        avatar: {
+            type: Object,
+            required: true
+        }
+    }
+};
+</script>
+
+<style scoped>
+.avatar-card {
+    background: #1e1e1e;
+    border-radius: 12px;
+    width: 200px;
+    padding: 5px;
+    box-sizing: border-box;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    text-align: center;
+    color: white;
+}
+.avatar {
+    width: 190px;
+    height: 190px;
+    object-fit: cover;
+    border-radius: 8px;
+    background-color: #1e1e1e;
+    display: block;
+    margin: 0 auto;
+}
+.avatar-name {
+    margin-top: 12px;
+    font-size: 16px;
+    font-weight: bold;
+}
+</style>

--- a/src/components/NavMenu.vue
+++ b/src/components/NavMenu.vue
@@ -40,6 +40,13 @@
             </template>
         </el-menu-item>
 
+        <el-menu-item index="avatarGallery">
+            <i class="el-icon-picture-outline"></i>
+            <template slot="title">
+                <span>{{ $t('nav_tooltip.avatar_gallery') }}</span>
+            </template>
+        </el-menu-item>
+
         <el-menu-item index="friendLog">
             <i class="el-icon-notebook-2"></i>
             <template slot="title">

--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -13,7 +13,8 @@
         "friend_list": "Friend List",
         "charts": "Charts",
         "profile": "Profile",
-        "settings": "Settings"
+        "settings": "Settings",
+        "avatar_gallery": "Avatar Gallery"
     },
     "view": {
         "login": {
@@ -238,7 +239,8 @@
                     "click_instance_name": "Click instance name to open Previous Instance Info dialog.",
                     "accuracy_notice": "Info from local database may not be accurate"
                 },
-                "settings": {
+                "settings": {,
+        "avatar_gallery": "Avatar Gallery"
                     "header": "Settings",
                     "bar_width": "Bar Width",
                     "show_solo_instance": "Show Solo Instance",
@@ -290,7 +292,8 @@
             "refresh_tooltip": "Refresh",
             "clear_results_tooltip": "Clear results"
         },
-        "settings": {
+        "settings": {,
+        "avatar_gallery": "Avatar Gallery"
             "header": "Settings",
             "category": {
                 "general": "General",

--- a/src/views/AvatarGallery/AvatarGallery.vue
+++ b/src/views/AvatarGallery/AvatarGallery.vue
@@ -1,0 +1,53 @@
+<template>
+    <div v-show="menuActiveIndex === 'avatarGallery'" class="x-container">
+        <div style="margin-bottom: 10px; display: flex; align-items: center;">
+            <el-select v-model="selectedTags" multiple clearable placeholder="Filter tags" style="flex:1;">
+                <el-option v-for="tag in allTags" :key="tag" :label="tag" :value="tag" />
+            </el-select>
+        </div>
+        <div class="avatar-gallery">
+            <AvatarCard v-for="avatar in filteredAvatars" :key="avatar.id" :avatar="avatar" />
+        </div>
+    </div>
+</template>
+
+<script>
+import AvatarCard from '../../components/AvatarCard.vue';
+export default {
+    name: 'AvatarGallery',
+    components: { AvatarCard },
+    inject: ['API'],
+    props: {
+        menuActiveIndex: String,
+        galleryAvatars: Array
+    },
+    data() {
+        return {
+            selectedTags: []
+        };
+    },
+    computed: {
+        allTags() {
+            const set = new Set();
+            for (const a of this.galleryAvatars) {
+                if (a.tags) {
+                    a.tags.forEach(t => set.add(t));
+                }
+            }
+            return Array.from(set);
+        },
+        filteredAvatars() {
+            if (!this.selectedTags.length) return this.galleryAvatars;
+            return this.galleryAvatars.filter(a => this.selectedTags.every(tag => a.tags && a.tags.includes(tag)));
+        }
+    }
+};
+</script>
+
+<style scoped>
+.avatar-gallery {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add Avatar Gallery page and card component
- hook Avatar Gallery into menu and main layout
- support Avatar Gallery data binding
- add localization entry

## Testing
- `npm run prod` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68739105c9bc8333b73bee3c5f49337d