### PR TITLE
Fix UI freeze on removing avatar gallery tags

### DIFF
--- a/src/views/AvatarGallery/AvatarGallery.vue
+++ b/src/views/AvatarGallery/AvatarGallery.vue
@@ -1,7 +1,13 @@
 <template>
     <div v-show="menuActiveIndex === 'avatarGallery'" class="x-container">
-        <div style="margin-bottom: 10px; display: flex; align-items: center;">
-            <el-select v-model="selectedTags" multiple clearable placeholder="Filter tags" style="flex:1;">
+        <div style="margin-bottom: 10px; display: flex; align-items: center">
+            <el-select
+                v-model="selectedTags"
+                multiple
+                clearable
+                collapse-tags
+                placeholder="Filter tags"
+                style="flex: 1">
                 <el-option v-for="tag in allTags" :key="tag" :label="tag" :value="tag" />
             </el-select>
         </div>
@@ -12,42 +18,44 @@
 </template>
 
 <script>
-import AvatarCard from '../../components/AvatarCard.vue';
-export default {
-    name: 'AvatarGallery',
-    components: { AvatarCard },
-    inject: ['API'],
-    props: {
-        menuActiveIndex: String,
-        galleryAvatars: Array
-    },
-    data() {
-        return {
-            selectedTags: []
-        };
-    },
-    computed: {
-        allTags() {
-            const set = new Set();
-            for (const a of this.galleryAvatars) {
-                if (a.tags) {
-                    a.tags.forEach(t => set.add(t));
-                }
-            }
-            return Array.from(set);
+    import AvatarCard from '../../components/AvatarCard.vue';
+    export default {
+        name: 'AvatarGallery',
+        components: { AvatarCard },
+        inject: ['API'],
+        props: {
+            menuActiveIndex: String,
+            galleryAvatars: Array
         },
-        filteredAvatars() {
-            if (!this.selectedTags.length) return this.galleryAvatars;
-            return this.galleryAvatars.filter(a => this.selectedTags.every(tag => a.tags && a.tags.includes(tag)));
+        data() {
+            return {
+                selectedTags: []
+            };
+        },
+        computed: {
+            allTags() {
+                const set = new Set();
+                for (const a of this.galleryAvatars) {
+                    if (a.tags) {
+                        a.tags.forEach((t) => set.add(t));
+                    }
+                }
+                return Array.from(set);
+            },
+            filteredAvatars() {
+                if (!this.selectedTags.length) return this.galleryAvatars;
+                return this.galleryAvatars.filter((a) =>
+                    this.selectedTags.every((tag) => a.tags && a.tags.includes(tag))
+                );
+            }
         }
-    }
-};
+    };
 </script>
 
 <style scoped>
-.avatar-gallery {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-}
+    .avatar-gallery {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+    }
 </style>


### PR DESCRIPTION
## Summary
- add `collapse-tags` to the avatar gallery tag filter to avoid UI freeze

## Testing
- `npm run prod`

------
https://chatgpt.com/codex/tasks/task_e_68739d15f6a08333ba8184aa44688a41