### PR TITLE
Improve AvatarCard layout for themes

### DIFF
--- a/src/components/AvatarCard.vue
+++ b/src/components/AvatarCard.vue
@@ -1,6 +1,11 @@
 <template>
-    <div class="avatar-card">
-        <img :src="avatar.thumbnailImageUrl" alt="Avatar" class="avatar" />
+    <div class="avatar-card" :style="cardStyle">
+        <img
+            :src="avatar.thumbnailImageUrl"
+            alt="Avatar"
+            class="avatar"
+            :style="imageStyle"
+        />
         <div class="avatar-name">{{ avatar.name }}</div>
     </div>
 </template>
@@ -13,27 +18,40 @@ export default {
             type: Object,
             required: true
         }
+    },
+    computed: {
+        isDarkMode() {
+            return this.$root.isDarkMode;
+        },
+        cardStyle() {
+            return {
+                background: this.isDarkMode ? '#1e1e1e' : '#ffffff',
+                color: this.isDarkMode ? '#ffffff' : '#000000'
+            };
+        },
+        imageStyle() {
+            return {
+                backgroundColor: this.isDarkMode ? '#1e1e1e' : '#f0f0f0'
+            };
+        }
     }
 };
 </script>
 
 <style scoped>
 .avatar-card {
-    background: #1e1e1e;
     border-radius: 12px;
     width: 200px;
     padding: 5px;
     box-sizing: border-box;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
     text-align: center;
-    color: white;
 }
 .avatar {
     width: 190px;
     height: 190px;
     object-fit: cover;
     border-radius: 8px;
-    background-color: #1e1e1e;
     display: block;
     margin: 0 auto;
 }
@@ -41,5 +59,8 @@ export default {
     margin-top: 12px;
     font-size: 16px;
     font-weight: bold;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 </style>


### PR DESCRIPTION
## Summary
- make AvatarCard background react to theme mode
- highlight card with a stronger shadow
- truncate long avatar names

## Testing
- `npm install`
- `npm run prod`

------
https://chatgpt.com/codex/tasks/task_e_68739e58d99c8333a3b7bbbb7afbd2d2