### PR TITLE
Fix AvatarGallery card alignment

### DIFF
--- a/src/views/AvatarGallery/AvatarGallery.vue
+++ b/src/views/AvatarGallery/AvatarGallery.vue
@@ -57,5 +57,6 @@
         display: flex;
         flex-wrap: wrap;
         gap: 10px;
+        justify-content: center;
     }
 </style>


### PR DESCRIPTION
## Summary
- center avatar gallery cards so left/right margins are even

## Testing
- `npx eslint -c .eslintrc.json src/views/AvatarGallery/AvatarGallery.vue` *(fails: ESLint couldn't find an eslint.config.*)*
- `npx prettier -c src/views/AvatarGallery/AvatarGallery.vue` *(fails: Cannot find package '@prettier/plugin-pug')*

------
https://chatgpt.com/codex/tasks/task_e_6873a323391c8333bb9efd4b4bfc10d9