### PR TITLE
Fix UI freeze when clearing last tag filter

### DIFF
--- a/src/views/AvatarGallery/AvatarGallery.vue
+++ b/src/views/AvatarGallery/AvatarGallery.vue
@@ -43,9 +43,12 @@
                 return Array.from(set);
             },
             filteredAvatars() {
-                if (!this.selectedTags.length) return this.galleryAvatars;
+                const tags = Array.isArray(this.selectedTags)
+                    ? this.selectedTags
+                    : [];
+                if (!tags.length) return this.galleryAvatars;
                 return this.galleryAvatars.filter((a) =>
-                    this.selectedTags.every((tag) => a.tags && a.tags.includes(tag))
+                    tags.every((tag) => a.tags && a.tags.includes(tag))
                 );
             }
         }


### PR DESCRIPTION
## Summary
- prevent null selected tag array from freezing Avatar Gallery

## Testing
- `npm install`
- `npm run prod`


------
https://chatgpt.com/codex/tasks/task_e_6873a7c5f80083339d292efb2e80ad48