### PR TITLE
Add search to avatar gallery

### DIFF
--- a/src/views/AvatarGallery/AvatarGallery.vue
+++ b/src/views/AvatarGallery/AvatarGallery.vue
@@ -10,6 +10,11 @@
                 style="flex: 1">
                 <el-option v-for="tag in allTags" :key="tag" :label="tag" :value="tag" />
             </el-select>
+            <el-input
+                v-model="searchQuery"
+                placeholder="Search name"
+                clearable
+                style="flex: none; width: 150px; margin-left: 10px" />
         </div>
         <div class="avatar-gallery">
             <AvatarCard v-for="avatar in filteredAvatars" :key="avatar.id" :avatar="avatar" />
@@ -29,7 +34,8 @@
         },
         data() {
             return {
-                selectedTags: []
+                selectedTags: [],
+                searchQuery: ''
             };
         },
         computed: {
@@ -46,10 +52,22 @@
                 const tags = Array.isArray(this.selectedTags)
                     ? this.selectedTags
                     : [];
-                if (!tags.length) return this.galleryAvatars;
-                return this.galleryAvatars.filter((a) =>
-                    tags.every((tag) => a.tags && a.tags.includes(tag))
-                );
+                const q = this.searchQuery.toLowerCase().trim();
+                return this.galleryAvatars.filter((a) => {
+                    if (
+                        tags.length &&
+                        !tags.every((tag) => a.tags && a.tags.includes(tag))
+                    ) {
+                        return false;
+                    }
+                    if (
+                        q &&
+                        !(a.name && a.name.toLowerCase().includes(q))
+                    ) {
+                        return false;
+                    }
+                    return true;
+                });
             }
         }
     };


### PR DESCRIPTION
## Summary
- add a text input to search avatars by name in the gallery
- filter gallery by search text and selected tags

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6873b23878048333a246d9e1fd4b8854