### PR TITLE
Add local avatar preview support

### DIFF
--- a/Dotnet/AppApi/Common/AvatarImages.cs
+++ b/Dotnet/AppApi/Common/AvatarImages.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using NLog;
+
+namespace VRCX;
+
+public partial class AppApi
+{
+    public string GetLocalAvatarImage(string avatarId)
+    {
+        try
+        {
+            var dir = Path.Join(Program.AppDataDirectory, "AvatarImages");
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            var file = Path.Join(dir, $"{avatarId}.png");
+            if (File.Exists(file))
+                return file;
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "Failed to get local avatar image");
+        }
+        return string.Empty;
+    }
+}

--- a/src/components/AvatarCard.vue
+++ b/src/components/AvatarCard.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="avatar-card" :style="cardStyle">
         <img
-            :src="avatar.thumbnailImageUrl"
+            :src="displayImage"
             alt="Avatar"
             class="avatar"
             :style="imageStyle"
@@ -21,6 +21,11 @@ export default {
             required: true
         }
     },
+    data() {
+        return {
+            localImage: ''
+        };
+    },
     computed: {
         isDarkMode() {
             return this.$root.isDarkMode;
@@ -35,12 +40,22 @@ export default {
             return {
                 backgroundColor: this.isDarkMode ? '#1e1e1e' : '#f0f0f0'
             };
+        },
+        displayImage() {
+            return this.localImage || this.avatar.thumbnailImageUrl;
         }
     },
     methods: {
         openAvatarDialog() {
             this.showAvatarDialog(this.avatar.id);
         }
+    },
+    created() {
+        AppApi.GetLocalAvatarImage(this.avatar.id).then((localPath) => {
+            if (localPath) {
+                this.localImage = `file://${localPath.replace(/\\/g, '/')}`;
+            }
+        });
     }
 };
 </script>


### PR DESCRIPTION
## Summary
- support optional local avatar gallery preview images
- show local thumbnails in avatar gallery when present

## Testing
- `npm run prod`

------
https://chatgpt.com/codex/tasks/task_e_6873bc8aab588333bafc898d6246cb77