### PR TITLE
Add invite-all button to favorite friend groups

### DIFF
--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -140,6 +140,7 @@
             "visibility_tooltip": "Change Visibility",
             "rename_tooltip": "Rename",
             "clear_tooltip": "Clear",
+            "invite_all_tooltip": "Invite all",
             "delete_tooltip": "Delete",
             "unavailable_tooltip": "Unavailable",
             "private": "Private",


### PR DESCRIPTION
## Summary
- enable inviting all online friends from a favorite group with one click
- show InviteDialog to choose invite message
- add English localization string for tooltip

## Testing
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687b7e1197f88333abafa3c98070cece