### PR TITLE
Show last seen instance in profile

### DIFF
--- a/src/components/dialogs/UserDialog/UserDialog.vue
+++ b/src/components/dialogs/UserDialog/UserDialog.vue
@@ -593,6 +593,18 @@
                                     :location="userDialog.ref.location"
                                     :traveling="userDialog.ref.travelingToLocation"
                                     style="display: block; margin-top: 5px" />
+                                <div
+                                    v-if="userDialog.lastInstance"
+                                    class="x-friend-item"
+                                    style="width: 100%; cursor: default; margin-top: 5px">
+                                    <div class="detail">
+                                        <span class="name">{{ t('dialog.user.info.last_seen_instance') }}</span>
+                                        <Location
+                                            class="extra"
+                                            :location="userDialog.lastInstance"
+                                            style="display: inline-block; margin-left: 5px" />
+                                    </div>
+                                </div>
                             </div>
                             <div class="x-friend-list" style="flex: 1; margin-top: 10px; max-height: 150px">
                                 <div

--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -775,6 +775,7 @@
                 "represented_group": "Represented Group",
                 "bio": "Bio",
                 "last_seen": "Last Seen",
+                "last_seen_instance": "Last Seen Instance",
                 "join_count": "Join Count",
                 "time_together": "Time Together",
                 "play_time": "Play Time",

--- a/src/service/database/gameLog.js
+++ b/src/service/database/gameLog.js
@@ -900,6 +900,21 @@ const gameLog = {
         return data;
     },
 
+    async getLastInstanceByUserId(input) {
+        let location = '';
+        await sqliteService.execute(
+            (row) => {
+                location = row[0];
+            },
+            `SELECT location FROM gamelog_join_leave WHERE user_id = @userId OR display_name = @displayName ORDER BY id DESC LIMIT 1`,
+            {
+                '@userId': input.id,
+                '@displayName': input.displayName
+            }
+        );
+        return location;
+    },
+
     async getPreviousInstancesByWorldId(input) {
         var data = new Map();
         await sqliteService.execute(

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -243,6 +243,7 @@ export const useUserStore = defineStore('User', () => {
             joinCount: 0,
             timeSpent: 0,
             lastSeen: '',
+            lastInstance: '',
             avatarModeration: 0,
             previousDisplayNames: [],
             dateFriended: '',
@@ -783,6 +784,7 @@ export const useUserStore = defineStore('User', () => {
             $thumbnailUrl: ''
         };
         D.lastSeen = '';
+        D.lastInstance = '';
         D.joinCount = 0;
         D.timeSpent = 0;
         D.avatarModeration = 0;
@@ -926,6 +928,13 @@ export const useUserStore = defineStore('User', () => {
                                         displayNameMapSorted.keys()
                                     );
                                 });
+                            database
+                                .getLastInstanceByUserId(D.ref)
+                                .then((loc) => {
+                                    if (D.id === userId) {
+                                        D.lastInstance = loc;
+                                    }
+                                });
                             AppApi.GetVRChatUserModeration(
                                 state.currentUser.id,
                                 userId
@@ -945,6 +954,13 @@ export const useUserStore = defineStore('User', () => {
                                         D.lastSeen = ref1.lastSeen;
                                         D.joinCount = ref1.joinCount;
                                         D.timeSpent = ref1.timeSpent;
+                                    }
+                                });
+                            database
+                                .getLastInstanceByUserId(D.ref)
+                                .then((loc) => {
+                                    if (D.id === userId) {
+                                        D.lastInstance = loc;
                                     }
                                 });
                         }


### PR DESCRIPTION
## Summary
- add `last_seen_instance` text
- query gamelog for user's last instance
- store last instance in user dialog
- show last seen instance in user dialog under current location

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887e931f33c8333b0c1e1fcc4861703