### PR TITLE
Add option to ban blocked users in groups

### DIFF
--- a/src/localization/cz/en.json
+++ b/src/localization/cz/en.json
@@ -1387,6 +1387,7 @@
             "actions": "Actions",
             "kick": "Kick",
             "ban": "Ban",
+            "ban_blocked": "Ban Blocked",
             "unban": "Unban",
             "save_note": "Save Note",
             "delete_sent_invite": "Delete Sent Invite",

--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -1552,6 +1552,7 @@
             "actions": "Actions",
             "kick": "Kick",
             "ban": "Ban",
+            "ban_blocked": "Ban Blocked",
             "unban": "Unban",
             "save_note": "Save Note",
             "delete_sent_invite": "Delete Sent Invite",

--- a/src/localization/es/en.json
+++ b/src/localization/es/en.json
@@ -1501,6 +1501,7 @@
             "actions": "Acciones",
             "kick": "Expulsar",
             "ban": "Prohibir",
+            "ban_blocked": "Ban Blocked",
             "unban": "Desprohibir",
             "save_note": "Guardar Nota",
             "delete_sent_invite": "Eliminar Invitación Enviada",

--- a/src/localization/fr/en.json
+++ b/src/localization/fr/en.json
@@ -1450,6 +1450,7 @@
             "actions": "Actions",
             "kick": "Expulser",
             "ban": "Bannir",
+            "ban_blocked": "Ban Blocked",
             "unban": "Débannir",
             "save_note": "Sauvegarder la note",
             "delete_sent_invite": "Supprimer l'invitation envoyée",

--- a/src/localization/hu/en.json
+++ b/src/localization/hu/en.json
@@ -1327,6 +1327,7 @@
             "actions": "Actions",
             "kick": "Kick",
             "ban": "Ban",
+            "ban_blocked": "Ban Blocked",
             "unban": "Unban",
             "save_note": "Save Note",
             "delete_sent_invite": "Delete Sent Invite",

--- a/src/localization/ja/en.json
+++ b/src/localization/ja/en.json
@@ -1545,6 +1545,7 @@
             "actions": "アクション",
             "kick": "キック",
             "ban": "BAN",
+            "ban_blocked": "Ban Blocked",
             "unban": "BAN解除",
             "save_note": "ノートを保存",
             "delete_sent_invite": "送信した招待を削除",

--- a/src/localization/ko/en.json
+++ b/src/localization/ko/en.json
@@ -1327,6 +1327,7 @@
             "actions": "Actions",
             "kick": "Kick",
             "ban": "Ban",
+            "ban_blocked": "Ban Blocked",
             "unban": "Unban",
             "save_note": "Save Note",
             "delete_sent_invite": "Delete Sent Invite",

--- a/src/localization/pl/en.json
+++ b/src/localization/pl/en.json
@@ -1327,6 +1327,7 @@
             "actions": "Akcje",
             "kick": "Wyrzuć",
             "ban": "Zbanuj",
+            "ban_blocked": "Ban Blocked",
             "unban": "Odbanuj",
             "save_note": "Zapisz notatkę",
             "delete_sent_invite": "Usuń wysłane zaproszenie",

--- a/src/localization/pt/en.json
+++ b/src/localization/pt/en.json
@@ -1327,6 +1327,7 @@
             "actions": "Ações",
             "kick": "Remover",
             "ban": "Banir",
+            "ban_blocked": "Ban Blocked",
             "unban": "Desbanir",
             "save_note": "Salvar Nota",
             "delete_sent_invite": "Excluir Convite Enviado",

--- a/src/localization/ru/en.json
+++ b/src/localization/ru/en.json
@@ -1513,6 +1513,7 @@
             "actions": "Действия",
             "kick": "Кик",
             "ban": "Бан",
+            "ban_blocked": "Ban Blocked",
             "unban": "Разбанить",
             "save_note": "Сохранить заметку",
             "delete_sent_invite": "Удалить отправленное приглашение",

--- a/src/localization/vi/en.json
+++ b/src/localization/vi/en.json
@@ -1327,6 +1327,7 @@
             "actions": "Actions",
             "kick": "Kick",
             "ban": "Ban",
+            "ban_blocked": "Ban Blocked",
             "unban": "Unban",
             "save_note": "Save Note",
             "delete_sent_invite": "Delete Sent Invite",

--- a/src/localization/zh-CN/en.json
+++ b/src/localization/zh-CN/en.json
@@ -1526,6 +1526,7 @@
             "actions": "操作",
             "kick": "踢出",
             "ban": "封禁",
+            "ban_blocked": "Ban Blocked",
             "unban": "解除封禁",
             "save_note": "保存备注",
             "delete_sent_invite": "删除已发送的邀请",

--- a/src/localization/zh-TW/en.json
+++ b/src/localization/zh-TW/en.json
@@ -1513,6 +1513,7 @@
             "actions": "操作",
             "kick": "踢出",
             "ban": "封禁",
+            "ban_blocked": "Ban Blocked",
             "unban": "解除封禁",
             "save_note": "儲存備註",
             "delete_sent_invite": "刪除已傳送的邀請",

--- a/src/service/database/moderation.js
+++ b/src/service/database/moderation.js
@@ -58,6 +58,19 @@ const moderation = {
                 '@user_id': userId
             }
         );
+    },
+
+    async getBlockedUsers() {
+        const result = [];
+        await sqliteService.execute(
+            (dbRow) => {
+                if (dbRow[3] === 1) {
+                    result.push(dbRow[0]);
+                }
+            },
+            `SELECT * FROM ${dbVars.userPrefix}_moderation WHERE block = 1`
+        );
+        return result;
     }
 };
 


### PR DESCRIPTION
## Summary
- extend database moderation API with `getBlockedUsers`
- add `ban_blocked` localization entry
- add a new `Ban Blocked` action button in group member moderation
- implement `banBlockedUsers` with rate limiting and skip already banned users

## Testing
- `npx eslint src/service/database/moderation.js src/components/dialogs/GroupDialog/GroupMemberModerationDialog.vue` *(fails: vue/valid-v-for)*

------
https://chatgpt.com/codex/tasks/task_e_688b58deef448333abf03aca01046fa5